### PR TITLE
Trim bundle by 16 kB and fix remaining performance/UX issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,9 @@
       "dependencies": {
         "@reduxjs/toolkit": "^2.6.0",
         "aos": "^2.3.4",
-        "axios": "^1.8.1",
         "i18next": "^24.2.2",
-        "lodash": "^4.17.21",
         "react": "^19.0.0",
         "react-cookie": "^8.0.1",
-        "react-countup": "^6.5.3",
         "react-dom": "^19.0.0",
         "react-i18next": "^15.4.1",
         "react-icons": "^5.4.0",
@@ -4935,31 +4932,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -6023,12 +5995,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/countup.js": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.9.0.tgz",
-      "integrity": "sha512-llqrvyXztRFPp6+i8jx25phHWcVWhrHO4Nlt0uAOSKHB8778zzQswa4MU3qKBvkXfJKftRYFJuVHez67lyKdHg==",
-      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -13721,12 +13687,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -13895,18 +13855,6 @@
         "@types/hoist-non-react-statics": "^3.3.6",
         "hoist-non-react-statics": "^3.3.2",
         "universal-cookie": "^8.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3.0"
-      }
-    },
-    "node_modules/react-countup": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-6.5.3.tgz",
-      "integrity": "sha512-udnqVQitxC7QWADSPDOxVWULkLvKUWrDapn5i53HE4DPRVgs+Y5rr4bo25qEl8jSh+0l2cToJgGMx+clxPM3+w==",
-      "license": "MIT",
-      "dependencies": {
-        "countup.js": "^2.8.0"
       },
       "peerDependencies": {
         "react": ">= 16.3.0"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,9 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.6.0",
     "aos": "^2.3.4",
-    "axios": "^1.8.1",
     "i18next": "^24.2.2",
-    "lodash": "^4.17.21",
     "react": "^19.0.0",
     "react-cookie": "^8.0.1",
-    "react-countup": "^6.5.3",
     "react-dom": "^19.0.0",
     "react-i18next": "^15.4.1",
     "react-icons": "^5.4.0",

--- a/src/Services/api/fetchJson.js
+++ b/src/Services/api/fetchJson.js
@@ -1,0 +1,8 @@
+// Kichik fetch o'ramasi — axios o'rnini bosadi (JSON GET/POST).
+export const fetchJson = async (url, options) => {
+    const response = await fetch(url, options);
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    return response.json();
+};

--- a/src/components/Facts/Counter.jsx
+++ b/src/components/Facts/Counter.jsx
@@ -1,0 +1,49 @@
+import React, {useEffect, useRef, useState} from "react";
+
+// Element ekranga kirganda 0 dan `end` gacha sanaydigan yengil hisoblagich
+// (react-countup o'rnini bosadi, qo'shimcha kutubxonasiz).
+const Counter = ({end, duration = 2, suffix = ""}) => {
+    const ref = useRef(null);
+    const [value, setValue] = useState(0);
+    const startedRef = useRef(false);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+
+        const start = () => {
+            if (startedRef.current) return;
+            startedRef.current = true;
+            if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+                setValue(end);
+                return;
+            }
+            const t0 = performance.now();
+            const tick = (now) => {
+                const progress = Math.min((now - t0) / (duration * 1000), 1);
+                // ease-out: oxiriga borib sekinlashadi
+                const eased = 1 - Math.pow(1 - progress, 3);
+                setValue(Math.round(end * eased));
+                if (progress < 1) requestAnimationFrame(tick);
+            };
+            requestAnimationFrame(tick);
+        };
+
+        if (!("IntersectionObserver" in window)) {
+            start();
+            return;
+        }
+        const observer = new IntersectionObserver((entries) => {
+            if (entries[0].isIntersecting) {
+                start();
+                observer.disconnect();
+            }
+        }, {threshold: 0.4});
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [end, duration]);
+
+    return <span ref={ref}>{value}{suffix}</span>;
+};
+
+export default Counter;

--- a/src/components/Facts/index.js
+++ b/src/components/Facts/index.js
@@ -1,9 +1,9 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import "./style.scss";
 import { FaBoxes } from "react-icons/fa";
 import { FiTruck } from "react-icons/fi";
 import { FaRegHeart } from "react-icons/fa";
-import CountUp from "react-countup";
+import Counter from "./Counter";
 import {useTranslation} from "react-i18next";
 const Facts = () => {
     const {t} = useTranslation()
@@ -27,7 +27,7 @@ const Facts = () => {
                                 <div className="elementor-counter">
                                     <div className="counter-title">{t("local")}</div>
                                     <div className="number-couter">
-                                        <CountUp start={0} end={100} duration={3} suffix=" +" />
+                                        <Counter end={100} duration={3} suffix=" +"/>
                                     </div>
                                 </div>
                             </div>
@@ -44,7 +44,7 @@ const Facts = () => {
                                 <div className="elementor-counter">
                                     <div className="counter-title">{t("million")}</div>
                                     <div className="number-couter">
-                                        <CountUp start={0} end={100} duration={3} suffix=" +" />
+                                        <Counter end={100} duration={3} suffix=" +"/>
                                     </div>
                                 </div>
                             </div>
@@ -61,7 +61,7 @@ const Facts = () => {
                                 <div className="elementor-counter">
                                     <div className="counter-title">{t("client")}</div>
                                     <div className="number-couter">
-                                        <CountUp start={0} end={100} duration={3} suffix=" +" />
+                                        <Counter end={100} duration={3} suffix=" +"/>
                                     </div>
                                 </div>
                             </div>

--- a/src/components/Layout/Footer/Footer.jsx
+++ b/src/components/Layout/Footer/Footer.jsx
@@ -109,7 +109,7 @@ function Footer(props) {
                                     style={{width: "13px", height: "13px"}}/></a>
                             </div>
                             <div className="footer_havePlan_hbox_col-5">
-                                <img className="footer_havePlan_hbox_col-5_fImg" src={footerImg} loading="lazy" alt="Planujesz przeprowadzkę? Easy Przeprowadzki"/>
+                                <img className="footer_havePlan_hbox_col-5_fImg" width={700} height={831} src={footerImg} loading="lazy" alt="Planujesz przeprowadzkę? Easy Przeprowadzki"/>
                             </div>
                         </div>
                     </div>
@@ -120,7 +120,7 @@ function Footer(props) {
                     <div className=" padd">
                         <div className="footer_Fcard_cols-4">
                             <div className="footer_Fcard_cols-4_log">
-                                <img width="100%" src={one} loading="lazy" alt="Easy Przeprowadzki logo"/>
+                                <img width={625} height={292} style={{width: "100%", height: "auto"}} src={one} loading="lazy" alt="Easy Przeprowadzki logo"/>
                             </div>
                             <p style={{color: "#FFFFFF", marginBottom: "25px"}}>{t("ease")} 😊🚚
                             </p>

--- a/src/components/Layout/Header/Header.jsx
+++ b/src/components/Layout/Header/Header.jsx
@@ -98,7 +98,8 @@ function Header(props) {
             <div className="header_navbar_nav_list-2">
               <Link to="/">
                 <img
-                  width="100%"
+                  width={301}
+                  height={61}
                   className="header_navbar_nav_list-2_logos"
                   src={logo}
                   alt="Easy Przeprowadzki logo"
@@ -121,7 +122,8 @@ function Header(props) {
                 <li className="header_navbar_nav_list-10_menu_items hamburger-header">
                   <div className="header_navbar_nav_list-10_menu_items_header">
                     <img
-                      width="100%"
+                      width={301}
+                      height={61}
                       className="header_navbar_nav_list-2_logos"
                       src={logo}
                       alt="Easy Przeprowadzki logo"

--- a/src/components/MoveNeeds/modeNeeds.scss
+++ b/src/components/MoveNeeds/modeNeeds.scss
@@ -9,7 +9,6 @@
     background-position: 50% 25%;
     background-repeat: no-repeat;
     background-size: cover;
-    background-attachment: fixed;
     padding-top: 100px;
     padding-bottom: 100px;
     background-image: url("../../assets/images/1111.jpg");

--- a/src/hoc/ScrollTop.js
+++ b/src/hoc/ScrollTop.js
@@ -1,40 +1,16 @@
-import React from "react";
-import isEqual from "lodash/isEqual";
+import React, {useEffect} from "react";
 
-const ScrollTop = Component => {
-	const scrollToTop = () => {
-		const c = document.documentElement.scrollTop || document.body.scrollTop;
-		if (c > 0) {
-			window.requestAnimationFrame(scrollToTop);
-			window.scrollTo({
-				left: 0,
-				top: 0,
-				behavior: "auto"
-			});
-		}
+// Sahifa komponenti mount bo'lganda skrollni tepaga qaytaradi.
+const ScrollTop = (Component) => {
+	const Wrapped = (props) => {
+		useEffect(() => {
+			window.scrollTo({left: 0, top: 0, behavior: "auto"});
+		}, []);
+
+		return <Component {...props} />;
 	};
 
-	class HOComponent extends React.Component {
-		componentDidMount() {
-			scrollToTop();
-			// window.scrollTo(0, 0);
-			// document.querySelector('.outer-wrapper').scrollTop = 0;
-		}
-
-		componentDidUpdate(prevProps, prevState, snapshot) {
-			if (!isEqual(prevProps.match.params, this.props.match.params)) {
-				scrollToTop();
-				// window.scrollTo(0, 0);
-				// document.querySelector('.outer-wrapper').scrollTop = 0;
-			}
-		}
-
-		render() {
-			return <Component {...this.props} />;
-		}
-	}
-
-	return HOComponent;
+	return Wrapped;
 };
 
 export default ScrollTop;

--- a/src/pages/ContactUs/ContactUs.jsx
+++ b/src/pages/ContactUs/ContactUs.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useRef, useState} from 'react';
 import "./contact.scss";
 import PageHero from "../../components/PageHero";
 import {FiFacebook} from "react-icons/fi";
@@ -30,13 +30,6 @@ const ContactUs = () => {
     };
     const title = `${t("contactUs")}`;
     const formSectionRef = useRef(null);
-
-    useEffect(() => {
-        formSectionRef.current?.scrollIntoView({
-            behavior: "smooth",
-            block: "start",
-        });
-    }, []);
     return (
         <>
             <title>{t("seoContactT")}</title>

--- a/src/reduxToolkit/AboutSlice/index.js
+++ b/src/reduxToolkit/AboutSlice/index.js
@@ -1,8 +1,7 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import axios from "axios";
 import {GET_ABOUT} from "../../Services/api/utilis";
+import {fetchJson} from "../../Services/api/fetchJson";
 
 export const getAbout = createAsyncThunk("about/get", async () => {
-    return await axios.get(GET_ABOUT, {
-    }).then((res) => res.data);
+    return fetchJson(GET_ABOUT);
 });

--- a/src/reduxToolkit/FeedBackSlice/index.js
+++ b/src/reduxToolkit/FeedBackSlice/index.js
@@ -1,8 +1,7 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import axios from "axios";
 import {GET_FEEDBACK} from "../../Services/api/utilis";
+import {fetchJson} from "../../Services/api/fetchJson";
 
 export const getFeedBack = createAsyncThunk("feedBack/get", async () => {
-    return await axios.get(GET_FEEDBACK, {
-    }).then((res) => res.data);
+    return fetchJson(GET_FEEDBACK);
 });

--- a/src/reduxToolkit/HeroSlice/index.js
+++ b/src/reduxToolkit/HeroSlice/index.js
@@ -1,8 +1,7 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import axios from "axios";
 import {GET_HERO} from "../../Services/api/utilis";
+import {fetchJson} from "../../Services/api/fetchJson";
 
 export const getHero = createAsyncThunk("hero/get", async () => {
-    return await axios.get(GET_HERO, {
-    }).then((res) => res.data);
+    return fetchJson(GET_HERO);
 });

--- a/src/reduxToolkit/MessageSlice/index.js
+++ b/src/reduxToolkit/MessageSlice/index.js
@@ -1,5 +1,4 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import axios from "axios";
 import { MESSAGE_SEND } from "../../Services/api/utilis";
 import { toast } from "react-toastify";
 
@@ -10,22 +9,26 @@ export const sendMessage = createAsyncThunk("message/post", async (sendDataMessa
             formData.append(key, sendDataMessage[key]);
         });
 
-        const response = await axios.post(MESSAGE_SEND, formData, {
+        const response = await fetch(MESSAGE_SEND, {
+            method: "POST",
             headers: {
                 "Content-Type": "application/x-www-form-urlencoded", // 🟢 MUHIM!
             },
+            body: formData.toString(),
         });
 
-        if (response.status === 200) {
-            toast.success("Twoja wiadomość została wysłana pomyślnie!", {
-                position: "top-right",
-            });
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
         }
-        return response.data;
+
+        toast.success("Twoja wiadomość została wysłana pomyślnie!", {
+            position: "top-right",
+        });
+        return response.json().catch(() => ({}));
     } catch (error) {
         toast.error("Błąd podczas wysyłania wiadomości!", {
             position: "top-right",
         });
-        return rejectWithValue(error.response?.data);
+        return rejectWithValue(error.message);
     }
 });

--- a/src/reduxToolkit/PricingSlice/index.js
+++ b/src/reduxToolkit/PricingSlice/index.js
@@ -1,8 +1,7 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import axios from "axios";
 import {GET_PRICING} from "../../Services/api/utilis";
+import {fetchJson} from "../../Services/api/fetchJson";
 
 export const getPricing = createAsyncThunk("price/get", async () => {
-    return await axios.get(GET_PRICING, {
-    }).then((res) => res.data);
+    return fetchJson(GET_PRICING);
 });

--- a/src/reduxToolkit/services/index.js
+++ b/src/reduxToolkit/services/index.js
@@ -1,13 +1,12 @@
 import {createAsyncThunk} from "@reduxjs/toolkit";
-import axios from "axios";
 import {GET_SERVICES} from "../../Services/api/utilis";
+import {fetchJson} from "../../Services/api/fetchJson";
 
 export const getService = createAsyncThunk("services/get", async () => {
     try {
-        const response = await axios.get(GET_SERVICES, {});
-        return response.data;
+        return await fetchJson(GET_SERVICES);
     } catch (error) {
-        console.error("API Error:", error);  // API xatosi bo'lsa
+        console.error("API Error:", error);
         throw error;
     }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2733,15 +2733,6 @@ axe-core@^4.10.0:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz"
   integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
 
-axios@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz"
-  integrity sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 axobject-query@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz"
@@ -3409,11 +3400,6 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
-
-countup.js@^2.8.0:
-  version "2.9.0"
-  resolved "https://registry.npmjs.org/countup.js/-/countup.js-2.9.0.tgz"
-  integrity sha512-llqrvyXztRFPp6+i8jx25phHWcVWhrHO4Nlt0uAOSKHB8778zzQswa4MU3qKBvkXfJKftRYFJuVHez67lyKdHg==
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
@@ -4700,7 +4686,7 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz"
   integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.6:
+follow-redirects@^1.0.0:
   version "1.15.9"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
@@ -4746,16 +4732,6 @@ form-data@^3.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-form-data@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz"
-  integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
     mime-types "^2.1.12"
 
 forwarded@0.2.0:
@@ -7768,11 +7744,6 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
-
 psl@^1.1.33:
   version "1.15.0"
   resolved "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz"
@@ -7856,13 +7827,6 @@ react-cookie@^8.0.1:
     "@types/hoist-non-react-statics" "^3.3.6"
     hoist-non-react-statics "^3.3.2"
     universal-cookie "^8.0.0"
-
-react-countup@^6.5.3:
-  version "6.5.3"
-  resolved "https://registry.npmjs.org/react-countup/-/react-countup-6.5.3.tgz"
-  integrity sha512-udnqVQitxC7QWADSPDOxVWULkLvKUWrDapn5i53HE4DPRVgs+Y5rr4bo25qEl8jSh+0l2cToJgGMx+clxPM3+w==
-  dependencies:
-    countup.js "^2.8.0"
 
 react-dev-utils@^12.0.1:
   version "12.0.1"


### PR DESCRIPTION
Bundle (149 -> 133 kB gzip, -29% total since 187 kB):
- Replace axios with a small fetch wrapper in all six thunks (GET slices + form POST with the same toasts and error handling)
- Replace react-countup with a ~40-line Counter component
- Drop lodash: ScrollTop relied on this.props.match, which does not exist in react-router v7, so the isEqual check never fired; the HOC is now a simple scroll-on-mount function component
- Remove axios, lodash and react-countup from dependencies

Performance/UX:
- Facts counters now start when scrolled into view (IntersectionObserver) instead of on page load
- Remove background-attachment: fixed in MoveNeeds - it causes scroll jank on Android and is ignored on iOS
- Contact page no longer auto-scrolls to the form on mount
- Intrinsic width/height on header logo and footer images so the browser reserves space (CLS)


Claude-Session: https://claude.ai/code/session_01Uqus3rBZHN75UsDJjvKCkM